### PR TITLE
remove _isComplete check, is inconsistent with checkCompletionStatus in ...

### DIFF
--- a/js/adapt-contrib-accordion.js
+++ b/js/adapt-contrib-accordion.js
@@ -4,6 +4,12 @@ define(function(require) {
 
   var Accordion = ComponentView.extend({
 
+    preRender: function() {
+      _.each(this.model.get('_items'), function(item) {
+        item._isVisited = false;
+      });
+    },
+
     postRender: function() {
       this.setReadyStatus();
     },


### PR DESCRIPTION
...other components. If this check is needed then would it be better if applied 1 time in parent class method? Causes issue in our fork where we are required to track subsequent attempts of components.
