### PR TITLE
Marked plugin as compatible with Adapt framework 2.X

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "adapt-contrib-accordion",
   "version": "0.0.2",
+  "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-accordion",
   "authors": [
     "Kevin Corry <kevinc@learningpool.com>"


### PR DESCRIPTION
I've used ^2.0.0 as the version tag... this assumes that all Adapt v2.X releases WILL NOT have breaking changes.
