### PR TITLE
remove _isComplete condition on setCompletionStatus

### DIFF
--- a/js/adapt-contrib-accordion.js
+++ b/js/adapt-contrib-accordion.js
@@ -76,10 +76,8 @@ define(function(require) {
         },
 
         checkCompletionStatus: function() {
-            if (!this.model.get('_isComplete')) {
-                if (this.getVisitedItems().length == this.model.get('_items').length) {
-                    this.setCompletionStatus();
-                }
+            if (this.getVisitedItems().length == this.model.get('_items').length) {
+                this.setCompletionStatus();
             }
         }
 


### PR DESCRIPTION
On revisit in LMS _isComplete is true but _isInteractionComplete is
false. Prevents _isInteractionComplete being set to true and trickle
etc from working.