### PR TITLE
Bug fix for revisited state

### DIFF
--- a/js/adapt-contrib-accordion.js
+++ b/js/adapt-contrib-accordion.js
@@ -25,11 +25,11 @@ define(function(require) {
             // If reset is enabled set defaults
             if (isResetOnRevisit) {
                 this.model.reset(isResetOnRevisit);
-            }
 
-            _.each(this.model.get('_items'), function(item) {
-                item._isVisited = false;
-            });
+                _.each(this.model.get('_items'), function(item) {
+                    item._isVisited = false;
+                });
+            }
         },
 
         toggleItem: function(event) {


### PR DESCRIPTION
Accordion was always reseting visited as `item._isVisited = false;` was outside of the `isResetOnRevisit` if statement