### PR TITLE
Accessibility - Normalize the aria-label

### DIFF
--- a/templates/accordion.hbs
+++ b/templates/accordion.hbs
@@ -3,7 +3,7 @@
     <div class="accordion-widget component-widget">
         {{#each _items}}
         <div class="accordion-item {{_classes}}">
-            <button role="button" class="base accordion-item-title {{#if _isVisited}}visited{{/if}}" aria-expanded="false" aria-label="{{{title}}}">
+            <button role="button" class="base accordion-item-title {{#if _isVisited}}visited{{/if}}" aria-expanded="false" aria-label="{{{a11y_normalize title}}}">
               <div class="accordion-item-title-inner">
                 <div class="accordion-item-title-icon icon icon-plus h5"></div>
                       {{{title}}}


### PR DESCRIPTION
The aria-label text could contain HTML tags, to avoid screen reader to read it it is necessary to remove those tags by normalizing it. 
IMO the `a11y_normalize` function should be used on all `aria-label`'s.
