### PR TITLE
adapt-contrib-accordion - jumps/scrolls when opening in IE 11

### DIFF
--- a/js/adapt-contrib-accordion.js
+++ b/js/adapt-contrib-accordion.js
@@ -84,7 +84,12 @@ define(function(require) {
             var $icon = $('.accordion-item-title-icon', $itemEl).first();
 
             $body = $body.stop(true, true).slideDown(this.toggleSpeed, function() {
-                $body.a11y_focus();
+                if (Adapt.config.has('_accessibility') && Adapt.config.get('_accessibility')._isActive) {
+                    _.delay(function() {
+                        // Allow animation to complete before focusing
+                        $body.a11y_focus();
+                   }, 500);
+                }
             });
 
             $button.addClass('selected');

--- a/js/adapt-contrib-accordion.js
+++ b/js/adapt-contrib-accordion.js
@@ -84,12 +84,12 @@ define(function(require) {
             var $icon = $('.accordion-item-title-icon', $itemEl).first();
 
             $body = $body.stop(true, true).slideDown(this.toggleSpeed, function() {
-                if (Adapt.config.has('_accessibility') && Adapt.config.get('_accessibility')._isActive) {
-                    _.delay(function() {
-                        // Allow animation to complete before focusing
-                        $body.a11y_focus();
-                   }, 500);
-                }
+                var a11y = Adapt.config.get('_accessibility');
+                if (!a11y || !a11y._isActive) return;
+                _.delay(function() {
+                    // Allow animation to complete before focusing
+                    $body.a11y_focus();
+                }, 500);
             });
 
             $button.addClass('selected');


### PR DESCRIPTION
Defensive code to execute focus only when accessibility is active, and delay the focus so a transition can complete.