### PR TITLE
fixes issue/#2071: switched to itemsComponentModel _children

### DIFF
--- a/js/accordionView.js
+++ b/js/accordionView.js
@@ -14,7 +14,7 @@ define([
 
             this.model.resetActiveItems();
 
-            this.listenTo(this.model.get('_items'), {
+            this.listenTo(this.model.get('_children'), {
                 'change:_isActive': this.onItemsActiveChange,
                 'change:_isVisited': this.onItemsVisitedChange
             });


### PR DESCRIPTION
[issue/#2071](https://github.com/adaptlearning/adapt_framework/issues/2071) moved to `_children` from `_items` for collection.

dependent on [pr/2072](https://github.com/adaptlearning/adapt_framework/pull/2072)