### PR TITLE
issue/2799 Removed redundant behaviour

### DIFF
--- a/js/adapt-contrib-accordion.js
+++ b/js/adapt-contrib-accordion.js
@@ -1,8 +1,8 @@
-import Adapt from 'core/js/adapt';
+import components from 'core/js/components';
 import AccordionModel from './AccordionModel';
 import AccordionView from './AccordionView';
 
-export default Adapt.register('accordion', {
+export default components.register('accordion', {
   model: AccordionModel,
   view: AccordionView
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-accordion",
   "version": "6.0.2",
-  "framework": ">=5.14.0",
+  "framework": ">=5.19.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-accordion",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-accordion/issues",
   "component" : "accordion",

--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { html, classes, compile, templates } from 'core/js/reactHelpers';
+import { classes, compile, templates } from 'core/js/reactHelpers';
 
 export default function Accordion (props) {
   const {
@@ -45,8 +45,7 @@ export default function Accordion (props) {
                 </div>
 
                 <div className="accordion-item__title">
-                  <div className="accordion-item__title-inner">
-                    {html(compile(title))}
+                  <div className="accordion-item__title-inner" dangerouslySetInnerHTML={{ __html: compile(title) }}>
                   </div>
                 </div>
 
@@ -64,8 +63,7 @@ export default function Accordion (props) {
 
                 {body &&
                 <div className="accordion-item__body">
-                  <div className="accordion-item__body-inner">
-                    {html(compile(body))}
+                  <div className="accordion-item__body-inner" dangerouslySetInnerHTML={{ __html: compile(body) }}>
                   </div>
                 </div>
                 }


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changes
* Switched from `Adapt.register` to `components.register`

### Fixed
* Use `dangerouslySetInnerHtml` instead of `html()`

