### PR TITLE
Optional chaining needed on graphic src check

### DIFF
--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -24,7 +24,7 @@ export default function Accordion (props) {
             className={classes([
               'accordion-item',
               'js-accordion-item',
-              _graphic.src && 'has-image',
+              _graphic?.src && 'has-image',
               _classes
             ])}
             key={_index}


### PR DESCRIPTION
Fixes #113
Optional chaining on _graphic src check to avoid attempt at reading property of null