### PR TITLE
issue/145 Automated aria levels

### DIFF
--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -31,7 +31,7 @@ export default function Accordion (props) {
             data-index={_index}
           >
 
-            <div role="heading" aria-level={a11y.ariaLevel('componentItem', itemAriaLevel)} >
+            <div role="heading" aria-level={a11y.ariaLevel({ id: _id, level: 'componentItem', override: itemAriaLevel })} >
               <button
                 id={`${_id}-${index}-accordion-button`}
                 className={classes([

--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -18,7 +18,7 @@ export default function Accordion (props) {
 
       <div className="component__widget accordion__widget">
 
-        {props._items.map(({ _graphic, _classes, title, body, _index, _isVisited, _isActive }, index) =>
+        {props._items.map(({ _graphic, _classes, title, body, _index, _isVisited, _isActive, _ariaLevel }, index) =>
 
           <div
             className={classes([
@@ -31,7 +31,7 @@ export default function Accordion (props) {
             data-index={_index}
           >
 
-            <div role="heading" aria-level={a11y.ariaLevel({ id: _id, level: 'componentItem', override: itemAriaLevel })} >
+            <div role="heading" aria-level={a11y.ariaLevel({ id: _id, level: 'componentItem', override: _ariaLevel ?? itemAriaLevel })} >
               <button
                 id={`${_id}-${index}-accordion-button`}
                 className={classes([


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt-contrib-core/issues/145

### Changed
* Supplied the component id to the `a11y.ariaLevel` function to aid automated calculations

### Added
* Item level `_ariaLevel` overrides

requires https://github.com/adaptlearning/adapt-contrib-core/pull/146