### PR TITLE
Missing semantic differentiation between status and heading

### DIFF
--- a/less/accordion.less
+++ b/less/accordion.less
@@ -17,6 +17,10 @@
     .icon-plus;
   }
 
+  &__btn.is-closed.is-visited .icon {
+    .icon-tick;
+  }
+
   &__btn.is-open .icon {
     .icon-minus;
   }

--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -4,7 +4,7 @@ import a11y from 'core/js/a11y';
 import { classes, compile, templates } from 'core/js/reactHelpers';
 
 export default function Accordion (props) {
-  const visited = Adapt.course.get('_globals')?._accessibility?._ariaLabels.visited;
+  const { complete, incomplete } = Adapt.course.get('_globals')?._accessibility?._ariaLabels;
   const {
     _id,
     _ariaLevel,
@@ -52,7 +52,7 @@ export default function Accordion (props) {
                   </span>
 
                   <span className="accordion-item__title">
-                    <span className="aria-label">{`${compile(title)} ${_isVisited ? '(' + visited + ')' : ''}`}</span>
+                    <span className="aria-label">{`${_isVisited ? complete : incomplete}. ${compile(title)}`}</span>
                     <span className="accordion-item__title-inner" aria-hidden="true" dangerouslySetInnerHTML={{ __html: compile(title) }}>
                     </span>
                   </span>

--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -4,7 +4,7 @@ import a11y from 'core/js/a11y';
 import { classes, compile, templates } from 'core/js/reactHelpers';
 
 export default function Accordion (props) {
-  const { complete, incomplete } = Adapt.course.get('_globals')?._accessibility?._ariaLabels;
+  const visited = Adapt.course.get('_globals')?._accessibility?._ariaLabels.visited;
   const {
     _id,
     _ariaLevel,
@@ -52,7 +52,7 @@ export default function Accordion (props) {
                   </span>
 
                   <span className="accordion-item__title">
-                    <span className="aria-label">{`${_isVisited ? complete : incomplete} ${compile(title)}`}</span>
+                    <span className="aria-label">{`${compile(title)} ${_isVisited && '(' + visited + ')'}`}</span>
                     <span className="accordion-item__title-inner" aria-hidden="true" dangerouslySetInnerHTML={{ __html: compile(title) }}>
                     </span>
                   </span>

--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -52,7 +52,7 @@ export default function Accordion (props) {
                   </span>
 
                   <span className="accordion-item__title">
-                    <span className="aria-label">{`${compile(title)} ${_isVisited && '(' + visited + ')'}`}</span>
+                    <span className="aria-label">{`${compile(title)} ${_isVisited ? '(' + visited + ')' : ''}`}</span>
                     <span className="accordion-item__title-inner" aria-hidden="true" dangerouslySetInnerHTML={{ __html: compile(title) }}>
                     </span>
                   </span>

--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -4,7 +4,7 @@ import a11y from 'core/js/a11y';
 import { classes, compile, templates } from 'core/js/reactHelpers';
 
 export default function Accordion (props) {
-  const { complete, incomplete } = Adapt.course.get('_globals')?._accessibility?._ariaLabels;
+  const visited = Adapt.course.get('_globals')?._accessibility?._ariaLabels.visited;
   const {
     _id,
     _ariaLevel,
@@ -52,7 +52,7 @@ export default function Accordion (props) {
                   </span>
 
                   <span className="accordion-item__title">
-                    <span className="aria-label">{`${_isVisited ? complete : incomplete}. ${compile(title)}`}</span>
+                    <span className="aria-label">{`${_isVisited ? visited + '. ' : ''}${compile(title)}`}</span>
                     <span className="accordion-item__title-inner" aria-hidden="true" dangerouslySetInnerHTML={{ __html: compile(title) }}>
                     </span>
                   </span>


### PR DESCRIPTION
fixes #118 

- Change plus icon to checkmark once the item has been visited.
- Use visited instead of complete/incomplete