### PR TITLE
Fix: Auto aria-levels (Issue #126)

### DIFF
--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -10,7 +10,7 @@ export default function Accordion (props) {
     _ariaLevel,
     onClick
   } = props;
-  const itemAriaLevel = _.isNumber(_ariaLevel) ? _ariaLevel + 1 : _ariaLevel;
+  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 : _ariaLevel;
   return (
     <div className="component__inner accordion__inner">
 

--- a/templates/accordion.jsx
+++ b/templates/accordion.jsx
@@ -10,7 +10,7 @@ export default function Accordion (props) {
     _ariaLevel,
     onClick
   } = props;
-  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 : _ariaLevel;
+  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 ? _ariaLevel + 1 : _ariaLevel;
   return (
     <div className="component__inner accordion__inner">
 


### PR DESCRIPTION
Fixes issue #126. 

Only likely to occur when courses are exported from the Adapt Authoring tool. 

Occurs when _ariaLevel exists and is the default value. Affects subheadings in component (when override exists and set to 0(zero)


