### PR TITLE
Fix: show tick icon when item visited (fixes #140)

### DIFF
--- a/less/accordion.less
+++ b/less/accordion.less
@@ -17,12 +17,8 @@
     .icon-plus;
   }
 
-  &__btn.is-closed.is-visited .icon {
+  &__btn.is-visited .icon {
     .icon-tick;
-  }
-
-  &__btn.is-open .icon {
-    .icon-minus;
   }
 
   // Set up margin between body and image elements


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-accordion/issues/140

Display the `tick` icon on visiting (expanding) an item. It is not necessary to collapse to complete the item. Amended for consistency with other components e.g. Hotgraphic only has `+` and `tick` icons.